### PR TITLE
Support query endpoint

### DIFF
--- a/lib/qdrant/points.rb
+++ b/lib/qdrant/points.rb
@@ -294,6 +294,45 @@ module Qdrant
       response.body
     end
 
+    # Universally query points. This endpoint covers all capabilities of search, recommend, discover, filters. But also enables hybrid and multi-stage queries.
+    def query(
+      collection_name:,
+      consistency: nil,
+      timeout: nil,
+      shard_key: nil,
+      prefetch: nil,
+      query: nil,
+      using: nil,
+      filter: nil,
+      params: nil,
+      score_threshold: nil,
+      limit: nil,
+      offset: nil,
+      with_vector: nil,
+      with_payload: nil,
+      lookup_from: nil
+    )
+      response = client.connection.post("collections/#{collection_name}/#{PATH}/query") do |req|
+        req.params["consistency"] = consistency unless consistency.nil?
+        req.params["timeout"] = timeout unless timeout.nil?
+
+        req.body = {}
+        req.body["shard_key"] = shard_key unless shard_key.nil?
+        req.body["prefetch"] = prefetch unless prefetch.nil?
+        req.body["query"] = query unless query.nil?
+        req.body["using"] = using unless using.nil?
+        req.body["filter"] = filter unless filter.nil?
+        req.body["params"] = params unless params.nil?
+        req.body["score_threshold"] = score_threshold unless score_threshold.nil?
+        req.body["limit"] = limit unless limit.nil?
+        req.body["offset"] = offset unless offset.nil?
+        req.body["with_vector"] = with_vector unless with_vector.nil?
+        req.body["with_payload"] = with_payload unless with_payload.nil?
+        req.body["lookup_from"] = lookup_from unless lookup_from.nil?
+      end
+      response.body
+    end
+
     # Count points which matches given filtering condition
     def count(
       collection_name:,

--- a/spec/qdrant/points_spec.rb
+++ b/spec/qdrant/points_spec.rb
@@ -290,4 +290,25 @@ RSpec.describe Qdrant::Points do
       expect(response.dig("status")).to eq("ok")
     end
   end
+
+  describe "#query" do
+    let(:response) {
+      OpenStruct.new(body: points_fixture)
+    }
+
+    before do
+      allow_any_instance_of(Faraday::Connection).to receive(:post)
+        .with("collections/test_collection/points/query")
+        .and_return(response)
+    end
+
+    it "return the data" do
+      response = client.points.query(
+        collection_name: "test_collection",
+        query: [0.05, 0.61, 0.76, 0.74],
+        limit: 10
+      )
+      expect(response.dig("result").count).to eq(5)
+    end
+  end
 end

--- a/spec/qdrant/points_spec.rb
+++ b/spec/qdrant/points_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe Qdrant::Points do
         .and_return(response)
     end
 
-    it "return the data" do
+    it "returns the data" do
       response = client.points.query(
         collection_name: "test_collection",
         query: [0.05, 0.61, 0.76, 0.74],


### PR DESCRIPTION
This PR supports the query endpoint. I tested it on one of my projects and it is working as expected.

Sample:

```ruby
Qdrant::Client.new(url: 'http://localhost:6333').points.query(
  collection_name: 'test',
  prefetch: [
    {
      query: dense_vector,
      using: 'dense',
      limit: 100
    },
    {
      query: {
        indices: sparse_indices,
        values: sparse_values
      },
      using: 'sparse',
      limit: 100
    }
  ],
  query: colbert_vectors,
  using: 'colbert',
  limit: 100
)
```